### PR TITLE
Update location of file containing Swagger file URL

### DIFF
--- a/.github/workflows/update-swagger.yml
+++ b/.github/workflows/update-swagger.yml
@@ -29,8 +29,8 @@ jobs:
           rm $RELEASE_TAG
           # Move index.html to the root
           mv dist/index.html .
-          # Fix references in index.html
-          sed -i "s|https://petstore.swagger.io/v2/swagger.json|$SWAGGER_YAML|g" index.html
+          # Fix references in dist/swagger-initializer and index.html
+          sed -i "s|https://petstore.swagger.io/v2/swagger.json|$SWAGGER_YAML|g" dist/swagger-initializer.js
           sed -i "s|href=\"./|href=\"dist/|g" index.html
           sed -i "s|src=\"./|src=\"dist/|g" index.html
           sed -i "s|href=\"index|href=\"dist/index|g" index.html


### PR DESCRIPTION
[This commit](https://github.com/swagger-api/swagger-ui/commit/ec51dc38e95ed2711fb333f89aad4c419670833c) to Swagger UI separated some code from index.html and placed it in the newly-added swagger-initializer.js. Due to this change, the workflow is unable to replace the reference to the local YAML file as it is no longer stored in index.html. To fix this, change where the workflow tries to replace this from index.html to swagger-initializer.js instead.